### PR TITLE
parameterized board member image sizes

### DIFF
--- a/content/nl/about/2022-2023/_index.md
+++ b/content/nl/about/2022-2023/_index.md
@@ -4,5 +4,6 @@ rank: 2
 # Image aspect ration needs to be 1:1 and at least 600x400
 image: "/images/about-us/bestuur-22_23.jpg"
 image_alt: "Een foto van het bestuur in studiejaar 2022-2023."
+orientation: "landscape"
 ---
 Het bestuur van 2022-2023. Van links naar rechts: penningmeester Robin Luijten, secretaris Jesse Krijgsman, voorzitter Guilliam Lutz en vice-voorzitter Luca Brugel.

--- a/content/nl/about/2022-2023/guilliam-lutz.md
+++ b/content/nl/about/2022-2023/guilliam-lutz.md
@@ -3,7 +3,6 @@ title: "Guilliam Lutz - voorzitter"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/guilliam-lutz-22_23.jpg"
 image_alt: "Een foto van voorzitter Guilliam Lutz"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 3 jaar geleden heb ik het idee gekregen een studievereniging op te richten voor Technische Informatica. Van wat ik hoorde hadden naast mij veel studenten behoefte aan een vereniging die de opleiding verrijkt. Het organiseren van evenementen met interessante onderwerpen die de opleiding niet aanbied. Maar ook een plek waar studenten laagdrempelig samen kunnen komen en plezier kunnen hebben. Inmiddels zit ik na het oprichtingsjaar in mijn 2e jaar als voorzitter en ik doe dit met veel plezier en passie. Voor vragen over de opleiding en de vereniging of al het andere kan je altijd bij mij terecht.

--- a/content/nl/about/2022-2023/jesse-krijgsman.md
+++ b/content/nl/about/2022-2023/jesse-krijgsman.md
@@ -3,7 +3,6 @@ title: "Jesse Krijgsman - secretaris"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/jesse-krijgsman-22_23.jpg"
 image_alt: "Een foto van secretaris Jesse Krijgsman"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Derde jaar student Technische Informatica. Ik zet mij in voor onze opleiding en vriendengroep, dit hoop ik ook te kunnen doen door onze studievereniging S.V. Promptus Imperii.

--- a/content/nl/about/2022-2023/luca-brugel.md
+++ b/content/nl/about/2022-2023/luca-brugel.md
@@ -3,7 +3,6 @@ title: "Luca Brugel - vice-voorzitter"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/luca-brugel-22_23.jpg"
 image_alt: "Een foto van vice-voorzitter Luca Brugel"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Derdejaars student Technische Informatica. Ik hoop door middel van de studievereniging onze studie te verbeteren en te verbinden.

--- a/content/nl/about/2022-2023/robin-luijten.md
+++ b/content/nl/about/2022-2023/robin-luijten.md
@@ -3,8 +3,7 @@ title: "Robin Luijten - penningmeester"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/robin-luijten-22_23.jpg"
 image_alt: "Een foto van Penningmeester Robin Luijten"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi, mijn naam is Robin. Ik ben 22 jaar oud en derdejaars student Technische Informatica.
 Ik ben momenteel de penningmeester van SV Promptus Imperii.

--- a/content/nl/about/2023-2024/_index.md
+++ b/content/nl/about/2023-2024/_index.md
@@ -4,5 +4,6 @@ rank: 1
 # Image aspect ration needs to be 1:1 and at least 600x400
 image: "/images/about-us/bestuur-23_24.jpg"
 image_alt: "Een foto van het bestuur in studiejaar 2023-2024."
+orientation: "landscape"
 ---
 Het bestuur van 2023-2024. Van links naar rechts: secretaris Stijn van Houwelingen, voorzitter Sam de Craen, vice-voorzitter Jesse Krijgsman en penningmeester Robin Luijten.

--- a/content/nl/about/2023-2024/jesse-krijgsman.md
+++ b/content/nl/about/2023-2024/jesse-krijgsman.md
@@ -3,8 +3,7 @@ title: "Jesse Krijgsman - vice-voorzitter"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/jesse-krijgsman-23_24.jpg"
 image_alt: "Een foto van vice-voorzitter Jesse Krijgsman"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi! Ik ben Jesse, ondertussen studeer ik al 4 jaar Technische Informatica aan Avans Hogeschool in Breda. Naast mijn studie zet ik mij in voor onze gave vereniging, S.V. Promptus Imperii, nu voor het tweede studiejaar op rij ben ik bestuurslid bij de verening.
 

--- a/content/nl/about/2023-2024/robin-luijten.md
+++ b/content/nl/about/2023-2024/robin-luijten.md
@@ -3,8 +3,7 @@ title: "Robin Luijten - penningmeester"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/robin-luijten-23_24.jpg"
 image_alt: "Een foto van penningmeester Robin Luijten"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi allemaal! 
 Ik ben Robin Luijten, 23 jaartjes jong, en ik ben de penningmeester van onze te gekke studievereniging. Mijn taak? Zorgen dat de centen kloppen, zodat we alle vette activiteiten kunnen blijven doen waar we zo van genieten.

--- a/content/nl/about/2023-2024/sam-de-craen.md
+++ b/content/nl/about/2023-2024/sam-de-craen.md
@@ -3,8 +3,7 @@ title: "Sam de Craen - voorzitter"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/sam-de-craen-23_24.jpg"
 image_alt: "Een foto van voorzitter Sam de Craen"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi, welkom op de website van onze vereniging! Mijn naam is Sam de Craen, de trotse voorzitter van onze studievereniging. Momenteel zit ik in mijn tweede jaar van Technische Informatica. Ik zet me graag in voor onze vereniging, omdat ik zie dat we voor velen een waardevolle aanvulling zijn op zowel hun studie als hun gehele studentenleven. Als vereniging streven we ernaar niet alleen de band tussen studenten te versterken, maar ook met het bedrijfsleven samen te werken. Samen met onze sponsoren bieden we onze leden een inkijkje in het gevarieerde en soms uitdagende werk dat ons vakgebied te bieden heeft.
 

--- a/content/nl/about/2023-2024/stijn-van-houwelingen.md
+++ b/content/nl/about/2023-2024/stijn-van-houwelingen.md
@@ -3,8 +3,7 @@ title: "Stijn van Houwelingen - secretaris"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/stijn-van-houwelingen-23_24.jpg"
 image_alt: "Een foto van secretaris Stijn van Houwelingen"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi, ik ben Stijn van Houwelingen en ben vierdejaars Informatica-student. Ik ben de secretaris van de vereniging. Ik was in 2023 de eerste Informatica-student die lid is geworden van de verening en mijn doel is om Informatica een volwaardig onderdeel te maken van de vereniging. 
 

--- a/content/nl/about/2024-2025/_index.md
+++ b/content/nl/about/2024-2025/_index.md
@@ -4,5 +4,6 @@ rank: 0
 # Image aspect ration needs to be 1:1 and at least 600x400
 image: "/images/about-us/bestuur-24_25.jpg"
 image_alt: "Een foto van het bestuur in studiejaar 2024-2025."
+orientation: "landscape"
 ---
 Het bestuur van 2024-2025. Van links naar rechts: commissieverantwoordelijke Max Hager, vice-voorzitter David van der Veer, voorzitter Sam de Craen, penningmeester Robin Luijten en secretaris Stijn van Houwelingen.

--- a/content/nl/about/2024-2025/david-van-der-veer.md
+++ b/content/nl/about/2024-2025/david-van-der-veer.md
@@ -3,8 +3,7 @@ title: "David van der Veer - vice-voorzitter"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/david-van-der-veer-24_25.jpg"
 image_alt: "Een foto van vice-voorzitter David van der Veer"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hey!
 Ik ben David van der Veer en ik ben tweedejaars student van Technische Informatica. Naast mijn studie houd ik me bezig met van alles: sleutelen aan mijn auto, foto's maken, en software ontwerpen en ontwikkelen, noem het maar op. In mijn eerste jaar ben ik veel betrokken geweest bij de vereniging al heb ik me toen niet aangesloten bij een commissie heb ik wel het hele jaar ambitie gehad mij verkiesbaar te stellen als bestuur.

--- a/content/nl/about/2024-2025/max-hager.md
+++ b/content/nl/about/2024-2025/max-hager.md
@@ -3,8 +3,7 @@ title: "Max Hager - commissieverantwoordelijke"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/max-hager-24_25.jpg"
 image_alt: "Een foto van commissieverantwoordelijke Max Hager"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Welkom! :) Mijn naam is Max Hager en ik zit momenteel in het derde jaar van Technische Informatica. Ik houd me actief bezig met het organiseren van activiteiten voor de vereniging. Ook vervul ik dit jaar de nieuwe bestuursrol van 'commissieverantwoordelijke': de communicatiebrug tussen het bestuur en de voorzitters van de verschillende commissies binnen de vereniging. In de praktijk help ik overal een handje.
 

--- a/content/nl/about/2024-2025/robin-luijten.md
+++ b/content/nl/about/2024-2025/robin-luijten.md
@@ -3,8 +3,7 @@ title: "Robin Luijten - penningmeester"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/robin-luijten-24_25.jpg"
 image_alt: "Een foto van penningmeester Robin Luijten"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi allemaal! 
 Ik ben Robin Luijten, 24 jaartjes jong, en ik ben de penningmeester van onze te gekke studievereniging. Mijn taak? Zorgen dat de centen kloppen, zodat we alle vette activiteiten kunnen blijven doen waar we zo van genieten.

--- a/content/nl/about/2024-2025/sam-de-craen.md
+++ b/content/nl/about/2024-2025/sam-de-craen.md
@@ -3,8 +3,7 @@ title: "Sam de Craen - voorzitter"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/sam-de-craen-24_25.jpg"
 image_alt: "Een foto van voorzitter Sam de Craen"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi, welkom op de website van onze vereniging! Mijn naam is Sam de Craen, de trotse voorzitter van onze studievereniging. Momenteel zit ik in mijn derde jaar van Technische Informatica. Ik zet me graag in voor onze vereniging, omdat ik zie dat we voor velen een waardevolle aanvulling zijn op zowel hun studie als hun gehele studentenleven. Als vereniging streven we ernaar niet alleen de band tussen studenten te versterken, maar ook met het bedrijfsleven samen te werken. Samen met onze sponsoren bieden we onze leden een inkijkje in het gevarieerde en soms uitdagende werk dat ons vakgebied te bieden heeft.
 

--- a/content/nl/about/2024-2025/stijn-van-houwelingen.md
+++ b/content/nl/about/2024-2025/stijn-van-houwelingen.md
@@ -3,8 +3,7 @@ title: "Stijn van Houwelingen - secretaris"
 # Image aspect ration needs to be 1:1 and at least 200*200
 image: "/images/about-us/stijn-van-houwelingen-24_25.jpg"
 image_alt: "Een foto van secretaris Stijn van Houwelingen"
-img_size_small: "300x200"
-img_size_large: "600x400"
+orientation: "landscape"
 ---
 Hoi, ik ben Stijn van Houwelingen en heb Informatica gestudeert. Vanuit het werkveld ben ik secretaris en bestuurslid van de vereniging.
 

--- a/themes/hugoplate/layouts/about/list.html
+++ b/themes/hugoplate/layouts/about/list.html
@@ -10,6 +10,14 @@
       </div>
   </div>
 
+  {{ $img_sizes_large := dict
+    "landscape" "600x400"
+    "portrait" "400x600"
+  }}
+  {{ $img_sizes_small := dict
+    "landscape" "300x200"
+    "portrait" "200x300"
+  }}
   {{ $sections := .Sections }}
   {{ $sorted_sections := sort $sections ".Params.rank" "asc"}}
 
@@ -20,7 +28,8 @@
         <div class="row justify-center">
           {{/* By default: first image then text (underneath each-other). On medium screens: text first then image (md:order-x)*/}}
           <div class="col-12 md:col-5 content md:order-2">
-            {{ partial "image" (dict "Src" .Params.image "Alt" .Params.image_alt "Class" "mx-auto mb-6 rounded-lg border-solid border" "Size" .Params.img_size_large) }}
+            {{ $img_size_large := index $img_sizes_large .Params.orientation }}
+            {{ partial "image" (dict "Src" .Params.image "Alt" .Params.image_alt "Class" "mx-auto mb-6 rounded-lg border-solid border" "Size" $img_size_large) }}
           </div>
           <div class="col-12 flex justify-center items-center md:col-5 pt-8 md:order-1 content">
             {{ .Content }}
@@ -30,7 +39,8 @@
           {{ $paginator := .Paginate .RegularPages }}
           {{ range $paginator.Pages }}
             <div class="md:col-10 lg:col-5 text-center">
-              {{ partial "image" (dict "Src" .Params.image "Alt" .Params.image_alt "Class" "mx-auto mb-6 rounded-lg border-solid border" "Size" .Params.img_size_small) }}
+              {{ $img_size_small := index $img_sizes_small .Params.orientation }}
+              {{ partial "image" (dict "Src" .Params.image "Alt" .Params.image_alt "Class" "mx-auto mb-6 rounded-lg border-solid border" "Size" $img_size_small) }}
               <h3 class="h3 mb-6">{{ .Title }}</h3>
               <div class="content">{{ .Content }}</div>
             </div>


### PR DESCRIPTION
This PR adds two simple parameters to configure the width and height of the member pictures on the about page. This change is required, as the board pictures of year 2025-2026 were shot in portrait mode rather than in landscape mode. Passing in different width and height for each picture will fix this issue.

The current board member pictures were updated to include this parameter.